### PR TITLE
Directory with lots of json-files as input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Code to download data from CrowdGrader assignments written in Python 2.
 
-Please feel free to contribute to this code. See http://doc.crowdgrader.org for more information on CrowdGrader.
+Please feel free to contribute to this code. See for more information on [CrowdGrader](http://doc.crowdgrader.org).
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
-crowdgrader-download-assignment
-===============================
+# crowdgrader-download-assignment
 
-Code to download data from CrowdGrader assignments.
-Please see http://doc.crowdgrader.org for more information on CrowdGrader, 
-and on downloading assignments. 
+> Code to download data from CrowdGrader assignments written in Python 2.
 
-Please feel free to contribute to this code.
+Please feel free to contribute to this code. See http://doc.crowdgrader.org for more information on CrowdGrader.
 
+
+## Usage
+
+    python ./download_assignment.py <json_source> <destination_folder>
+
+* `json_source` is a path to the JSON-file downloaded from Crowdgrader or the path to a folder containing multiple JSON-files.
+* `destination_folder` is the folder the assignments are stored. Each assignment has it own subfolder.
+
+Find more information and how to download assignment files in JSON on [crowdgrader.org](http://doc.crowdgrader.org/crowdgrader-documentation/downloading-all-data)
+
+## License
+
+crowdgrader-download-assignment is released under the MIT license. See [LICENSE](LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Please feel free to contribute to this code. See http://doc.crowdgrader.org for 
 
     python ./download_assignment.py <json_source> <destination_folder>
 
-* `json_source` is a path to the JSON-file downloaded from Crowdgrader or the path to a folder containing multiple JSON-files.
+* `json_source` is a path to a JSON-file downloaded from Crowdgrader describing assignments or a path to a folder containing multiple JSON-files.
 * `destination_folder` is the folder the assignments are stored. Each assignment has it own subfolder.
 
 Find more information and how to download assignment files in JSON on [crowdgrader.org](http://doc.crowdgrader.org/crowdgrader-documentation/downloading-all-data)
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please feel free to contribute to this code. See for more information on [CrowdG
 * `json_source` is a path to a JSON-file downloaded from Crowdgrader describing assignments or a path to a folder containing multiple JSON-files.
 * `destination_folder` is the folder the assignments are stored. Each assignment has it own subfolder.
 
-Find more information and how to download assignment files in JSON on [crowdgrader.org](http://doc.crowdgrader.org/crowdgrader-documentation/downloading-all-data)
+Find more information and how to download assignment files in JSON on [CrowdGrader Documentation](http://doc.crowdgrader.org/crowdgrader-documentation/downloading-all-data)
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please feel free to contribute to this code. See for more information on [CrowdG
 * `json_source` is a path to a JSON-file downloaded from Crowdgrader describing assignments or a path to a folder containing multiple JSON-files.
 * `destination_folder` is the folder the assignments are stored. Each assignment has it own subfolder.
 
-Find more information and how to download assignment files in JSON on [CrowdGrader Documentation](http://doc.crowdgrader.org/crowdgrader-documentation/downloading-all-data)
+Find more information and how to download assignment files in JSON on [CrowdGrader Documentation](http://doc.crowdgrader.org/crowdgrader-documentation/downloading-all-data).
 
 
 ## License

--- a/download_assignment.py
+++ b/download_assignment.py
@@ -57,14 +57,15 @@ def main():
 
     input_source = sys.argv[1] # to be tested for directory containing lots of json-files or one single json-file
     if os.path.isdir(input_source):
-        json_file_names = [input_source+file_name for file_name in os.listdir(input_source)]
+        json_file_names = [input_source+file_name for file_name in os.listdir(input_source) if file_name.endswith('.json')]
     else:
         json_file_names = [input_source]
 
     for i, json_file_name in enumerate(json_file_names):
         print "Start downloading assignment %i of %i" % (i+1, len(json_file_names))
         assignment_data = read_json_file(json_file_name)
-        write_assignment_data(dest_dir, assignment_data)
+        assignment_name = assignment_data["Assignment"]
+        write_assignment_data(dest_dir+assignment_name+"/", assignment_data)
 
     print "All assignment data downloaded."
 

--- a/download_assignment.py
+++ b/download_assignment.py
@@ -50,14 +50,21 @@ def main():
         usage()
         sys.exit(2)
 
-    json_file_name = sys.argv[1]
     dest_dir = sys.argv[2]
     if check_directory_exists(dest_dir):
         print "Error: Destination directory already exists."
         sys.exit(1)
 
-    assignment_data = read_json_file(json_file_name)
-    write_assignment_data(dest_dir, assignment_data)
+    input_source = sys.argv[1] # to be tested for directory containing lots of json-files or one single json-file
+    if os.path.isdir(input_source):
+        json_file_names = [input_source+file_name for file_name in os.listdir(input_source)]
+    else:
+        json_file_names = [input_source]
+
+    for i, json_file_name in enumerate(json_file_names):
+        print "Start downloading assignment %i of %i" % (i+1, len(json_file_names))
+        assignment_data = read_json_file(json_file_name)
+        write_assignment_data(dest_dir, assignment_data)
 
     print "All assignment data downloaded."
 

--- a/download_assignment.py
+++ b/download_assignment.py
@@ -57,7 +57,7 @@ def main():
 
     input_source = sys.argv[1] # to be tested for directory containing lots of json-files or one single json-file
     if os.path.isdir(input_source):
-        json_file_names = [input_source+file_name for file_name in os.listdir(input_source) if file_name.endswith('.json')]
+        json_file_names = [os.path.join(input_source, file_name) for file_name in os.listdir(input_source) if file_name.endswith('.json')]
     else:
         json_file_names = [input_source]
 
@@ -65,7 +65,7 @@ def main():
         print "Start downloading assignment %i of %i" % (i+1, len(json_file_names))
         assignment_data = read_json_file(json_file_name)
         assignment_name = assignment_data["Assignment"]
-        write_assignment_data(dest_dir+assignment_name+"/", assignment_data)
+        write_assignment_data(os.path.join(dest_dir, assignment_name), assignment_data)
 
     print "All assignment data downloaded."
 


### PR DESCRIPTION
The command line accepts now a folder containing lots of json-files or one single json-file:

`python /path/to/folder/withJSONs/xy.json /for/result/` (up to now) or

`python /path/to/folder/withJSONs/ /for/result/` (new)

Each assignment is stored in a separate subfolder named after the assignment.

